### PR TITLE
fix error on delete

### DIFF
--- a/src/base-service-mongoose.ts
+++ b/src/base-service-mongoose.ts
@@ -162,9 +162,9 @@ export default abstract class BaseServiceMongoose<T extends mongoose.Document>
       id: entity.id
     };
   }
-  public async delete(user: any, _id: any): Promise<void> {
-    const entity = await this.Model.findById(_id).lean();
+  public async delete(user: any, id: any): Promise<void> {
+    const entity = await this.Model.findById(id).lean();
     if (!entity) throw "Entity not found";
-    await this.Model.deleteOne({ _id });
+    await this.Model.deleteOne({ _id: id });
   }
 }

--- a/src/base-service-mongoose.ts
+++ b/src/base-service-mongoose.ts
@@ -162,9 +162,9 @@ export default abstract class BaseServiceMongoose<T extends mongoose.Document>
       id: entity.id
     };
   }
-  public async delete(user: any, id: any): Promise<void> {
-    const entity = await this.Model.findById(id).lean();
+  public async delete(user: any, _id: any): Promise<void> {
+    const entity = await this.Model.findById(_id).lean();
     if (!entity) throw "Entity not found";
-    await this.Model.deleteOne(id);
+    await this.Model.deleteOne({ _id });
   }
 }


### PR DESCRIPTION
Fix error when trying to delete. Throws:

`'Parameter "filter" to deleteOne() must be an object, got {{id}}'`

Whole exception

```
|❗️ 🔥 | Parameter "filter" to deleteOne() must be an object, got 5ee2d182244b867f04803067 {}
| 🔥 |-         [08c06381-0a3f-46ce-b48c-34c416a9a49f]
| 🔥 | Type: ObjectParameterError - LogInfo: {} ObjectParameterError: Parameter "filter" to deleteOne() must be an object, got 5ee2d182244b867f04803067
    at model.Query.Query.deleteOne (/home/lucashamaguchi/projects/lucashamaguchi/xhelpers-todo-sample-api/node_modules/mongoose/lib/query.js:2717:16)
    at Function.deleteOne (/home/lucashamaguchi/projects/lucashamaguchi/xhelpers-todo-sample-api/node_modules/mongoose/lib/model.js:1928:13)
    at TodoService.<anonymous> (/home/lucashamaguchi/projects/lucashamaguchi/xhelpers-todo-sample-api/dist/services/todo.js:31:30)
    at Generator.next (<anonymous>)
    at fulfilled (/home/lucashamaguchi/projects/lucashamaguchi/xhelpers-todo-sample-api/dist/services/todo.js:5:58)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
| 🔥 |-         [08c06381-0a3f-46ce-b48c-34c416a9a49f]
| 5️⃣ | SafeCall time: 12.849ms```